### PR TITLE
Feature/sveltekit typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
  
  <sub>**_Application is currently in its alpha stage_**.</sub>
 
-</div> 
+</div>
 
 ## Features
 
@@ -22,13 +22,11 @@
    
   </summary>
 
-  > - Words in the document with `\ backslashes \` surrounding it will be a Wordiable.
-  > - Up to seven Wordibles can be created, each with its assigned color.
-  > - Colors are applied to each iteration of the word in the document.
- 
+> - Words in the document with `\ backslashes \` surrounding it will be a Wordiable.
+> - Up to seven Wordibles can be created, each with its assigned color.
+> - Colors are applied to each iteration of the word in the document.
+
 </details>
-
-
 
 <details>
   <summary>
@@ -37,7 +35,7 @@
    
   </summary>
 
- > A table of the selected words will show the order in which the Wordibles first occur, how many times they appear on the document, and its associated color. Selecting a word from here will highlight the Wordiable from the document and allow you to update all occurrences at once.  <sub>_feature in progress!_</sub>    
+> A table of the selected words will show the order in which the Wordibles first occur, how many times they appear on the document, and its associated color. Selecting a word from here will highlight the Wordiable from the document and allow you to update all occurrences at once. <sub>_feature in progress!_</sub>
 
 </details>
 
@@ -45,30 +43,28 @@
  
 ## Wireframe
 
- 
 > Feel free to explore my wireframe and thoughts on [Figma](https://www.figma.com/file/gQ7y0NcZqBecv25aPrDzOI/Lettra?node-id=0%3A1)
- 
 
 ![lettra](https://user-images.githubusercontent.com/17935770/165384152-b341c29a-24f2-437a-8f36-b065a66c115a.png)
- </div>
 
+ </div>
 
 ## Installation
 
 You can visit [Lettra's website](https://lettra.vercel.app) or clone the repo.
 
-1. Clone the repo and update the dependency with your preferred package manager. <sub>(*yarn, pnpm, etc.*)</sub>
+1. Clone the repo and update the dependency with your preferred package manager. <sub>(_yarn, pnpm, etc._)</sub>
 
-    ```jsx
-    git clone
-    npm install
-    ```
+   ```jsx
+   git clone
+   npm install
+   ```
 
 2. Run the development environment to start the server.
 
-    ```jsx
-    npm run dev
-    ```
+   ```jsx
+   npm run dev
+   ```
 
 3. Once started, visit [localhost:5173](http://localhost::5173) on your browser.
 
@@ -76,7 +72,7 @@ You can visit [Lettra's website](https://lettra.vercel.app) or clone the repo.
 
 Insert your cover letter and then wrap backslashes (`\`) behind _and_ in front of the words you want to convert into a Wordiable.<sup>(word variable)</sup>
 
-> **For example**: `Dear OmniBark Hirer,` should look like `Dear \OmniBark\ Hirer,`  
+> **For example**: `Dear OmniBark Hirer,` should look like `Dear \OmniBark\ Hirer,`
 
 Do this to each word you would like to swap out for another easily, up to seven unique words.
 
@@ -86,7 +82,7 @@ In the previous example, every iteration of `\OmniBark\` will turn red. If you w
 
 > **For Example**: `\Dear\ \OmniBark\ Hirer,`
 
-In this example,`\Dear\`  (and any of the following iterations of the word) will turn red, and all instances of `OmniBark` will now be orange.
+In this example,`\Dear\` (and any of the following iterations of the word) will turn red, and all instances of `OmniBark` will now be orange.
 
 <!-- Not a feature yet: You only need to do this to the first iteration of the word seen in your document; then, every iteration afterward will become a **Wordiable** and can be manipulated all at once. -->
 
@@ -94,6 +90,7 @@ In this example,`\Dear\`  (and any of the following iterations of the word) will
  Dear \OmniBark\ Hirer,
  I would love to work at \OmniBark\ because...
 ```
+
 <!-- This is not a feature yet
 Select OmniBark from the Wordiable Table, or edit the word without removing the `\` (in any order), which will update the appearances of all the other words that are the same. If you replace `\OmniBark\` with `\UniMeows\` will automatically change the document from
 
@@ -112,11 +109,9 @@ to
   - Wordiables will be consistent in each stored paragraph to further increase the efficiency of creating versions of cover letters for when applying to companies with different core values or positions.
 - Add 'auto-detect Wordiables' feature that will try and determine which words are the ones the job-seeker would've chosen manually.
 
-
 <div align='center'>
 
 ## Technologies
-
 
 <img src="https://img.shields.io/badge/Svelte-FF3E00?logo=svelte&logoColor=fff&style=flat" alt="Svelte Badge">
 <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=fff&style=flat-square" alt="TypeScript Badge">
@@ -129,8 +124,6 @@ to
 <div align="center">
 
 ---
- 
- 
 
 ### Created by **Andrew Vallejo**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "lettra-client",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lettra-client",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"dependencies": {
 				"sass": "^1.54.0"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
 	"name": "lettra-client",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "lettra-client",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"dependencies": {
-				"jsdoc": "^3.6.11",
 				"sass": "^1.54.0"
 			},
 			"devDependencies": {
@@ -31,27 +30,32 @@
 				"vite": "^3.0.0"
 			}
 		},
-		"node_modules/@babel/parser": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-			"integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
-			"integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
+			"integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
 			"dev": true
 		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.9.tgz",
+			"integrity": "sha512-VZPy/ETF3fBG5PiinIkA0W/tlsvlEgJccyN2DzWZEl0DlVKRbu91PvY2D6Lxgluj4w9QtYHjOWjAT44C+oQ+EQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.9.tgz",
+			"integrity": "sha512-O+NfmkfRrb3uSsTa4jE3WApidSe3N5++fyOVGP1SmMZi4A3BZELkhUUvj5hwmMuNdlpzAZ8iAPz2vmcR7DCFQA==",
 			"cpu": [
 				"loong64"
 			],
@@ -65,14 +69,14 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"globals": "^13.15.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -82,12 +86,15 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-			"integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
+			"integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
 			"dev": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -103,6 +110,19 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
 			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
 			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
@@ -146,9 +166,9 @@
 			}
 		},
 		"node_modules/@mapbox/node-pre-gyp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
-			"integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+			"integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
 			"dev": true,
 			"dependencies": {
 				"detect-libc": "^2.0.0",
@@ -163,6 +183,26 @@
 			},
 			"bin": {
 				"node-pre-gyp": "bin/node-pre-gyp"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -201,13 +241,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
-			"integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+			"integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
-				"playwright-core": "1.25.0"
+				"playwright-core": "1.26.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -215,6 +255,12 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/@polka/url": {
+			"version": "1.0.0-next.21",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+			"dev": true
 		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "4.2.1",
@@ -230,84 +276,92 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "1.0.0-next.64",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.64.tgz",
-			"integrity": "sha512-Q8DwcS6wl1GovzS9JJzaD/WL/Lfk1ur4nAF1HtmsUvZDpsPBVDqnK2AhYU4G3oFNiuHstrjAogMy5th8ptSFGw==",
+			"version": "1.0.0-next.80",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.80.tgz",
+			"integrity": "sha512-352WoZr9fQgxJqgNENvxRr2gsA+wTF6V9AVaQaaatDYd3RVEBaXTYOOalFaRLSa25mRUJaLYP2aaliqczMl23g==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/adapter-cloudflare": "1.0.0-next.31",
-				"@sveltejs/adapter-netlify": "1.0.0-next.71",
-				"@sveltejs/adapter-vercel": "1.0.0-next.66"
+				"@sveltejs/adapter-cloudflare": "1.0.0-next.38",
+				"@sveltejs/adapter-netlify": "1.0.0-next.78",
+				"@sveltejs/adapter-vercel": "1.0.0-next.77"
 			}
 		},
 		"node_modules/@sveltejs/adapter-cloudflare": {
-			"version": "1.0.0-next.31",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-1.0.0-next.31.tgz",
-			"integrity": "sha512-HhEFZP72GJ8AZGgFECKIiayDcLaAWi65pI0AnBfiNhCifYSlH/mPNWNVD4AWRDnXnH6XU+FLwhGDnIDwytTyYg==",
+			"version": "1.0.0-next.38",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-1.0.0-next.38.tgz",
+			"integrity": "sha512-N6jdTomRZkdKlcNoguwYD7lpdXSt0beIyUJsp0MS/YLm/4gI83y698zFYInFKJ9t5e6DAnuEBSAXcg568z2oFA==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/workers-types": "^3.14.0",
-				"esbuild": "^0.14.48",
+				"esbuild": "^0.15.7",
 				"worktop": "0.8.0-next.14"
 			}
 		},
 		"node_modules/@sveltejs/adapter-netlify": {
-			"version": "1.0.0-next.71",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.71.tgz",
-			"integrity": "sha512-la1CGtWO1xul1L3zEoFAoc4EX2uxZjrZcOMS3tkKB8drxhbQsNbnTE6fmSSMFiZXhxaikczrBgQwqIaDkLTmZg==",
+			"version": "1.0.0-next.78",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.78.tgz",
+			"integrity": "sha512-Yyn/j/0QcLK3Db442ducLUZmyvkO74j7Gdcwu9xN0fQN3kBlCJP9Itx5o4SySrPFGc4Q8cLJ5ELNg+mWduLBAA==",
 			"dev": true,
 			"dependencies": {
 				"@iarna/toml": "^2.2.5",
-				"esbuild": "^0.14.48",
-				"set-cookie-parser": "^2.4.8",
-				"tiny-glob": "^0.2.9"
+				"esbuild": "^0.15.7",
+				"set-cookie-parser": "^2.4.8"
 			}
 		},
 		"node_modules/@sveltejs/adapter-vercel": {
-			"version": "1.0.0-next.66",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.66.tgz",
-			"integrity": "sha512-s3Hcxu9nCG/rR3C3cFbdQGjTa5W4K2kRcc6S5Xefx7itbrw+4v3KpO8ZPB6qM55XDwVxuG7260NMHVI6MUGmSA==",
+			"version": "1.0.0-next.77",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.77.tgz",
+			"integrity": "sha512-r4MqtP+lzx83HfcvI8PU0Yxzmxt6WQq9nzZETLboJouJzhSBUFIN5RmNZfEn6nNIlUwZbGQUEK/FxsRnnxI/Ig==",
 			"dev": true,
 			"dependencies": {
-				"@vercel/nft": "^0.21.0",
-				"esbuild": "^0.14.48"
+				"@vercel/nft": "^0.22.0",
+				"esbuild": "^0.15.7"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.405",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.405.tgz",
-			"integrity": "sha512-jHSa74F7k+hC+0fof75g/xm/+1M5sM66Qt6v8eLLMSgjkp36Lb5xOioBhbl6w0NYoE5xysLsBWuu+yHytfvCBA==",
+			"version": "1.0.0-next.503",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.503.tgz",
+			"integrity": "sha512-QSEHe40qMOYjXirxS57dIa9NU4FntlYh+KYslBzasjMCfSiUkHGaWMJRz8uU+R4BWnThD9SdCo7F/NwDxu5LRQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.1",
-				"chokidar": "^3.5.3",
+				"@sveltejs/vite-plugin-svelte": "^1.0.5",
+				"@types/cookie": "^0.5.1",
+				"cookie": "^0.5.0",
+				"devalue": "^3.1.2",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.26.2",
+				"mime": "^3.0.0",
+				"node-fetch": "^3.2.4",
 				"sade": "^1.8.1",
-				"tiny-glob": "^0.2.9"
+				"set-cookie-parser": "^2.4.8",
+				"sirv": "^2.0.2",
+				"tiny-glob": "^0.2.9",
+				"undici": "^5.8.1"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": ">=16.9"
+				"node": ">=16.14"
 			},
 			"peerDependencies": {
 				"svelte": "^3.44.0",
-				"vite": "^3.0.0"
+				"vite": "^3.1.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
-			"integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.8.tgz",
+			"integrity": "sha512-1xkVTB4pm6zuign858FzVYE9Fdw9MQBOlxrdd85STV0NvTDmcofcRpcrK+zcIyT8SZ2dseHLu8hvDwzssF6RfA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^4.2.1",
 				"debug": "^4.3.4",
 				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.2",
-				"svelte-hmr": "^0.14.12"
+				"magic-string": "^0.26.3",
+				"svelte-hmr": "^0.15.0"
 			},
 			"engines": {
 				"node": "^14.18.0 || >= 16"
@@ -329,35 +383,22 @@
 			"integrity": "sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==",
 			"dev": true
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
+			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
+			"dev": true
+		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
-		"node_modules/@types/linkify-it": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
-		},
-		"node_modules/@types/markdown-it": {
-			"version": "12.2.3",
-			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-			"dependencies": {
-				"@types/linkify-it": "*",
-				"@types/mdurl": "*"
-			}
-		},
-		"node_modules/@types/mdurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
-		},
 		"node_modules/@types/node": {
-			"version": "18.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.3.tgz",
-			"integrity": "sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==",
+			"version": "18.7.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+			"integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==",
 			"dev": true
 		},
 		"node_modules/@types/pug": {
@@ -376,16 +417,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
-			"integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
+			"integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/type-utils": "5.33.0",
-				"@typescript-eslint/utils": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/type-utils": "5.38.0",
+				"@typescript-eslint/utils": "5.38.0",
 				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
@@ -409,14 +449,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
-			"integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
+			"integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/typescript-estree": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -436,13 +476,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
-			"integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+			"integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/visitor-keys": "5.33.0"
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/visitor-keys": "5.38.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -453,12 +493,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
-			"integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
+			"integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
+				"@typescript-eslint/utils": "5.38.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -479,9 +520,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
-			"integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+			"integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -492,13 +533,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
-			"integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+			"integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/visitor-keys": "5.33.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/visitor-keys": "5.38.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -519,15 +560,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
-			"integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
+			"integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/typescript-estree": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -543,12 +584,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
-			"integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+			"integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/types": "5.38.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -560,9 +601,9 @@
 			}
 		},
 		"node_modules/@vercel/nft": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.21.0.tgz",
-			"integrity": "sha512-hFCAETfI5cG8l5iAiLhMC2bReC5K7SIybzrxGorv+eGspIbIFsVw7Vg85GovXm/LxA08pIDrAlrhR6GN36XB/Q==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.22.1.tgz",
+			"integrity": "sha512-lYYZIoxRurqDOSoVIdBicGnpUIpfyaS5qVjdPq+EfI285WqtZK3NK/dyCkiyBul+X2U2OEhRyeMdXPCHGJbohw==",
 			"dev": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.5",
@@ -694,7 +735,8 @@
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -734,11 +776,6 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"node_modules/bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -776,17 +813,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/catharsis": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-			"dependencies": {
-				"lodash": "^4.17.15"
-			},
-			"engines": {
-				"node": ">= 10"
 			}
 		},
 		"node_modules/chalk": {
@@ -829,6 +855,17 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/chownr": {
@@ -879,6 +916,15 @@
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
 		},
+		"node_modules/cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -891,6 +937,15 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/debug": {
@@ -949,6 +1004,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/devalue": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-3.1.3.tgz",
+			"integrity": "sha512-9KO89Cb+qjzf2CqdrH+NuLaqdk9GhDP5EhR4zlkR51dvuIaiqtlkDkGzLMShDemwUy21raSMdu+kpX8Enw3yGQ==",
+			"dev": true
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -979,14 +1040,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"node_modules/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -994,9 +1047,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.9.tgz",
+			"integrity": "sha512-OnYr1rkMVxtmMHIAKZLMcEUlJmqcbxBz9QoBU8G9v455na0fuzlT/GLu6l+SRghrk0Mm2fSSciMmzV43Q8e0Gg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1006,33 +1059,34 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/linux-loong64": "0.14.54",
-				"esbuild-android-64": "0.14.54",
-				"esbuild-android-arm64": "0.14.54",
-				"esbuild-darwin-64": "0.14.54",
-				"esbuild-darwin-arm64": "0.14.54",
-				"esbuild-freebsd-64": "0.14.54",
-				"esbuild-freebsd-arm64": "0.14.54",
-				"esbuild-linux-32": "0.14.54",
-				"esbuild-linux-64": "0.14.54",
-				"esbuild-linux-arm": "0.14.54",
-				"esbuild-linux-arm64": "0.14.54",
-				"esbuild-linux-mips64le": "0.14.54",
-				"esbuild-linux-ppc64le": "0.14.54",
-				"esbuild-linux-riscv64": "0.14.54",
-				"esbuild-linux-s390x": "0.14.54",
-				"esbuild-netbsd-64": "0.14.54",
-				"esbuild-openbsd-64": "0.14.54",
-				"esbuild-sunos-64": "0.14.54",
-				"esbuild-windows-32": "0.14.54",
-				"esbuild-windows-64": "0.14.54",
-				"esbuild-windows-arm64": "0.14.54"
+				"@esbuild/android-arm": "0.15.9",
+				"@esbuild/linux-loong64": "0.15.9",
+				"esbuild-android-64": "0.15.9",
+				"esbuild-android-arm64": "0.15.9",
+				"esbuild-darwin-64": "0.15.9",
+				"esbuild-darwin-arm64": "0.15.9",
+				"esbuild-freebsd-64": "0.15.9",
+				"esbuild-freebsd-arm64": "0.15.9",
+				"esbuild-linux-32": "0.15.9",
+				"esbuild-linux-64": "0.15.9",
+				"esbuild-linux-arm": "0.15.9",
+				"esbuild-linux-arm64": "0.15.9",
+				"esbuild-linux-mips64le": "0.15.9",
+				"esbuild-linux-ppc64le": "0.15.9",
+				"esbuild-linux-riscv64": "0.15.9",
+				"esbuild-linux-s390x": "0.15.9",
+				"esbuild-netbsd-64": "0.15.9",
+				"esbuild-openbsd-64": "0.15.9",
+				"esbuild-sunos-64": "0.15.9",
+				"esbuild-windows-32": "0.15.9",
+				"esbuild-windows-64": "0.15.9",
+				"esbuild-windows-arm64": "0.15.9"
 			}
 		},
 		"node_modules/esbuild-android-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.9.tgz",
+			"integrity": "sha512-HQCX7FJn9T4kxZQkhPjNZC7tBWZqJvhlLHPU2SFzrQB/7nDXjmTIFpFTjt7Bd1uFpeXmuwf5h5fZm+x/hLnhbw==",
 			"cpu": [
 				"x64"
 			],
@@ -1046,9 +1100,9 @@
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.9.tgz",
+			"integrity": "sha512-E6zbLfqbFVCNEKircSHnPiSTsm3fCRxeIMPfrkS33tFjIAoXtwegQfVZqMGR0FlsvVxp2NEDOUz+WW48COCjSg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1062,9 +1116,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.9.tgz",
+			"integrity": "sha512-gI7dClcDN/HHVacZhTmGjl0/TWZcGuKJ0I7/xDGJwRQQn7aafZGtvagOFNmuOq+OBFPhlPv1T6JElOXb0unkSQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1078,9 +1132,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.9.tgz",
+			"integrity": "sha512-VZIMlcRN29yg/sv7DsDwN+OeufCcoTNaTl3Vnav7dL/nvsApD7uvhVRbgyMzv0zU/PP0xRhhIpTyc7lxEzHGSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1094,9 +1148,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.9.tgz",
+			"integrity": "sha512-uM4z5bTvuAXqPxrI204txhlsPIolQPWRMLenvGuCPZTnnGlCMF2QLs0Plcm26gcskhxewYo9LkkmYSS5Czrb5A==",
 			"cpu": [
 				"x64"
 			],
@@ -1110,9 +1164,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.9.tgz",
+			"integrity": "sha512-HHDjT3O5gWzicGdgJ5yokZVN9K9KG05SnERwl9nBYZaCjcCgj/sX8Ps1jvoFSfNCO04JSsHSOWo4qvxFuj8FoA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1126,9 +1180,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.9.tgz",
+			"integrity": "sha512-AQIdE8FugGt1DkcekKi5ycI46QZpGJ/wqcMr7w6YUmOmp2ohQ8eO4sKUsOxNOvYL7hGEVwkndSyszR6HpVHLFg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1142,9 +1196,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.9.tgz",
+			"integrity": "sha512-4RXjae7g6Qs7StZyiYyXTZXBlfODhb1aBVAjd+ANuPmMhWthQilWo7rFHwJwL7DQu1Fjej2sODAVwLbcIVsAYQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1158,9 +1212,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.9.tgz",
+			"integrity": "sha512-3Zf2GVGUOI7XwChH3qrnTOSqfV1V4CAc/7zLVm4lO6JT6wbJrTgEYCCiNSzziSju+J9Jhf9YGWk/26quWPC6yQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1174,9 +1228,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.9.tgz",
+			"integrity": "sha512-a+bTtxJmYmk9d+s2W4/R1SYKDDAldOKmWjWP0BnrWtDbvUBNOm++du0ysPju4mZVoEFgS1yLNW+VXnG/4FNwdQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1190,9 +1244,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.9.tgz",
+			"integrity": "sha512-Zn9HSylDp89y+TRREMDoGrc3Z4Hs5u56ozZLQCiZAUx2+HdbbXbWdjmw3FdTJ/i7t5Cew6/Q+6kfO3KCcFGlyw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1206,9 +1260,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.9.tgz",
+			"integrity": "sha512-OEiOxNAMH9ENFYqRsWUj3CWyN3V8P3ZXyfNAtX5rlCEC/ERXrCEFCJji/1F6POzsXAzxvUJrTSTCy7G6BhA6Fw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1222,9 +1276,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.9.tgz",
+			"integrity": "sha512-ukm4KsC3QRausEFjzTsOZ/qqazw0YvJsKmfoZZm9QW27OHjk2XKSQGGvx8gIEswft/Sadp03/VZvAaqv5AIwNA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1238,9 +1292,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.9.tgz",
+			"integrity": "sha512-uDOQEH55wQ6ahcIKzQr3VyjGc6Po/xblLGLoUk3fVL1qjlZAibtQr6XRfy5wPJLu/M2o0vQKLq4lyJ2r1tWKcw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1254,9 +1308,9 @@
 			}
 		},
 		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.9.tgz",
+			"integrity": "sha512-yWgxaYTQz+TqX80wXRq6xAtb7GSBAp6gqLKfOdANg9qEmAI1Bxn04IrQr0Mzm4AhxvGKoHzjHjMgXbCCSSDxcw==",
 			"cpu": [
 				"x64"
 			],
@@ -1270,9 +1324,9 @@
 			}
 		},
 		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.9.tgz",
+			"integrity": "sha512-JmS18acQl4iSAjrEha1MfEmUMN4FcnnrtTaJ7Qg0tDCOcgpPPQRLGsZqhes0vmx8VA6IqRyScqXvaL7+Q0Uf3A==",
 			"cpu": [
 				"x64"
 			],
@@ -1286,9 +1340,9 @@
 			}
 		},
 		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.9.tgz",
+			"integrity": "sha512-UKynGSWpzkPmXW3D2UMOD9BZPIuRaSqphxSCwScfEE05Be3KAmvjsBhht1fLzKpiFVJb0BYMd4jEbWMyJ/z1hQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1302,9 +1356,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.9.tgz",
+			"integrity": "sha512-aqXvu4/W9XyTVqO/hw3rNxKE1TcZiEYHPsXM9LwYmKSX9/hjvfIJzXwQBlPcJ/QOxedfoMVH0YnhhQ9Ffb0RGA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1318,9 +1372,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.9.tgz",
+			"integrity": "sha512-zm7h91WUmlS4idMtjvCrEeNhlH7+TNOmqw5dJPJZrgFaxoFyqYG6CKDpdFCQXdyKpD5yvzaQBOMVTCBVKGZDEg==",
 			"cpu": [
 				"x64"
 			],
@@ -1334,9 +1388,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.9.tgz",
+			"integrity": "sha512-yQEVIv27oauAtvtuhJVfSNMztJJX47ismRS6Sv2QMVV9RM+6xjbMWuuwM2nxr5A2/gj/mu2z9YlQxiwoFRCfZA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1362,14 +1416,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.22.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
-			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@eslint/eslintrc": "^1.3.2",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -1379,13 +1434,12 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.3",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -1394,6 +1448,7 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -1404,8 +1459,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -1510,22 +1564,10 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/eslint/node_modules/glob-parent": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
-			"dependencies": {
-				"is-glob": "^4.0.3"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			}
-		},
 		"node_modules/espree": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-			"integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
@@ -1612,9 +1654,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1625,6 +1667,18 @@
 			},
 			"engines": {
 				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -1646,6 +1700,29 @@
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -1707,10 +1784,22 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
 		},
 		"node_modules/fs-minipass": {
 			"version": "2.1.0",
@@ -1747,12 +1836,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"node_modules/gauge": {
@@ -1796,14 +1879,15 @@
 			}
 		},
 		"node_modules/glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
 			"dependencies": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/globals": {
@@ -1856,7 +1940,8 @@
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true
 		},
 		"node_modules/grapheme-splitter": {
 			"version": "1.0.4",
@@ -2033,6 +2118,12 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"node_modules/js-sdsl": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+			"dev": true
+		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2043,61 +2134,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/js2xmlparser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-			"dependencies": {
-				"xmlcreate": "^2.0.4"
-			}
-		},
-		"node_modules/jsdoc": {
-			"version": "3.6.11",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
-			"dependencies": {
-				"@babel/parser": "^7.9.4",
-				"@types/markdown-it": "^12.2.3",
-				"bluebird": "^3.7.2",
-				"catharsis": "^0.9.0",
-				"escape-string-regexp": "^2.0.0",
-				"js2xmlparser": "^4.0.2",
-				"klaw": "^3.0.0",
-				"markdown-it": "^12.3.2",
-				"markdown-it-anchor": "^8.4.1",
-				"marked": "^4.0.10",
-				"mkdirp": "^1.0.4",
-				"requizzle": "^0.2.3",
-				"strip-json-comments": "^3.1.0",
-				"taffydb": "2.6.2",
-				"underscore": "~1.13.2"
-			},
-			"bin": {
-				"jsdoc": "jsdoc.js"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/jsdoc/node_modules/escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jsdoc/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/json-schema-traverse": {
@@ -2111,14 +2147,6 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
-		},
-		"node_modules/klaw": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-			"dependencies": {
-				"graceful-fs": "^4.1.9"
-			}
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -2142,14 +2170,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-			"dependencies": {
-				"uc.micro": "^1.0.1"
-			}
-		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2164,11 +2184,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
@@ -2189,9 +2204,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+			"version": "0.26.4",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.4.tgz",
+			"integrity": "sha512-e5uXtVJ22aEpK9u1+eQf0fSxHeqwyV19K+uGnlROCxUhzwRip9tBsaMViK/0vC3viyPd5Gtucp3UmEp/Q2cPTQ==",
 			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
@@ -2224,46 +2239,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-			"dependencies": {
-				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			},
-			"bin": {
-				"markdown-it": "bin/markdown-it.js"
-			}
-		},
-		"node_modules/markdown-it-anchor": {
-			"version": "8.6.4",
-			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-			"integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
-			"peerDependencies": {
-				"@types/markdown-it": "*",
-				"markdown-it": "*"
-			}
-		},
-		"node_modules/marked": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2284,6 +2259,18 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"dev": true,
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/min-indent": {
@@ -2392,24 +2379,41 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
 		"node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "3.2.10",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+			"integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
 			"dev": true,
 			"dependencies": {
-				"whatwg-url": "^5.0.0"
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
 			},
 			"engines": {
-				"node": "4.x || >=6.0.0"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/node-gyp-build": {
@@ -2595,9 +2599,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
-			"integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+			"integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
 			"dev": true,
 			"bin": {
 				"playwright": "cli.js"
@@ -2739,14 +2743,6 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
-		"node_modules/requizzle": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-			"dependencies": {
-				"lodash": "^4.17.14"
-			}
-		},
 		"node_modules/resolve": {
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -2799,9 +2795,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.77.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -2908,9 +2904,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.54.4",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-			"integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+			"integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -2976,6 +2972,20 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
+		},
+		"node_modules/sirv": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
+			"integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
+			"dev": true,
+			"dependencies": {
+				"@polka/url": "^1.0.0-next.20",
+				"mrmime": "^1.0.0",
+				"totalist": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -3066,6 +3076,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -3098,18 +3109,18 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.49.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-			"integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+			"version": "3.50.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
+			"integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.8.0.tgz",
-			"integrity": "sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.9.0.tgz",
+			"integrity": "sha512-9AVrtP7WbfDgCdqTZNPdj5CCCy1OrYMxFVWAWzNw7fl93c9klFJFtqzVXa6fovfQ050CcpUyJE2dPFL9TFAREw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.9",
@@ -3129,9 +3140,9 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.14.12",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.12.tgz",
-			"integrity": "sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.0.tgz",
+			"integrity": "sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==",
 			"dev": true,
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
@@ -3215,11 +3226,6 @@
 				"sourcemap-codec": "^1.4.8"
 			}
 		},
-		"node_modules/taffydb": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
-		},
 		"node_modules/tar": {
 			"version": "6.1.11",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
@@ -3274,6 +3280,15 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/totalist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.0.tgz",
+			"integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/tr46": {
@@ -3334,9 +3349,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -3346,15 +3361,14 @@
 				"node": ">=4.2.0"
 			}
 		},
-		"node_modules/uc.micro": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-		},
-		"node_modules/underscore": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-			"integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+		"node_modules/undici": {
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+			"integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.18"
+			}
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -3371,22 +3385,16 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-			"dev": true
-		},
 		"node_modules/vite": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.7.tgz",
-			"integrity": "sha512-dILhvKba1mbP1wCezVQx/qhEK7/+jVn9ciadEcyKMMhZpsuAi/eWZfJRMkmYlkSFG7Qq9NvJbgFq4XOBxugJsA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
+			"integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.14.47",
+				"esbuild": "^0.15.6",
 				"postcss": "^8.4.16",
 				"resolve": "^1.22.1",
-				"rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+				"rollup": "~2.78.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -3416,6 +3424,15 @@
 				"terser": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -3486,11 +3503,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
-		"node_modules/xmlcreate": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
-		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3511,33 +3523,35 @@
 		}
 	},
 	"dependencies": {
-		"@babel/parser": {
-			"version": "7.19.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-			"integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw=="
-		},
 		"@cloudflare/workers-types": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.14.1.tgz",
-			"integrity": "sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-3.16.0.tgz",
+			"integrity": "sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==",
 			"dev": true
 		},
+		"@esbuild/android-arm": {
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.9.tgz",
+			"integrity": "sha512-VZPy/ETF3fBG5PiinIkA0W/tlsvlEgJccyN2DzWZEl0DlVKRbu91PvY2D6Lxgluj4w9QtYHjOWjAT44C+oQ+EQ==",
+			"dev": true,
+			"optional": true
+		},
 		"@esbuild/linux-loong64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.9.tgz",
+			"integrity": "sha512-O+NfmkfRrb3uSsTa4jE3WApidSe3N5++fyOVGP1SmMZi4A3BZELkhUUvj5hwmMuNdlpzAZ8iAPz2vmcR7DCFQA==",
 			"dev": true,
 			"optional": true
 		},
 		"@eslint/eslintrc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
-			"integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+			"integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.3.2",
+				"espree": "^9.4.0",
 				"globals": "^13.15.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -3547,9 +3561,9 @@
 			}
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-			"integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+			"version": "0.10.5",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.5.tgz",
+			"integrity": "sha512-XVVDtp+dVvRxMoxSiSfasYaG02VEe1qH5cKgMQJWhol6HwzbcqoCMJi8dAGoYAO57jhUyhI6cWuRiTcRaDaYug==",
 			"dev": true,
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
@@ -3561,6 +3575,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
 			"integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
+			"dev": true
+		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
@@ -3598,9 +3618,9 @@
 			}
 		},
 		"@mapbox/node-pre-gyp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
-			"integrity": "sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
+			"integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
 			"dev": true,
 			"requires": {
 				"detect-libc": "^2.0.0",
@@ -3612,6 +3632,17 @@
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
 				"tar": "^6.1.11"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				}
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -3641,14 +3672,20 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
-			"integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.0.tgz",
+			"integrity": "sha512-D24pu1k/gQw3Lhbpc38G5bXlBjGDrH5A52MsrH12wz6ohGDeQ+aZg/JFSEsT/B3G8zlJe/EU4EkJK74hpqsjEg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"playwright-core": "1.25.0"
+				"playwright-core": "1.26.0"
 			}
+		},
+		"@polka/url": {
+			"version": "1.0.0-next.21",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
+			"dev": true
 		},
 		"@rollup/pluginutils": {
 			"version": "4.2.1",
@@ -3661,73 +3698,81 @@
 			}
 		},
 		"@sveltejs/adapter-auto": {
-			"version": "1.0.0-next.64",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.64.tgz",
-			"integrity": "sha512-Q8DwcS6wl1GovzS9JJzaD/WL/Lfk1ur4nAF1HtmsUvZDpsPBVDqnK2AhYU4G3oFNiuHstrjAogMy5th8ptSFGw==",
+			"version": "1.0.0-next.80",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.80.tgz",
+			"integrity": "sha512-352WoZr9fQgxJqgNENvxRr2gsA+wTF6V9AVaQaaatDYd3RVEBaXTYOOalFaRLSa25mRUJaLYP2aaliqczMl23g==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/adapter-cloudflare": "1.0.0-next.31",
-				"@sveltejs/adapter-netlify": "1.0.0-next.71",
-				"@sveltejs/adapter-vercel": "1.0.0-next.66"
+				"@sveltejs/adapter-cloudflare": "1.0.0-next.38",
+				"@sveltejs/adapter-netlify": "1.0.0-next.78",
+				"@sveltejs/adapter-vercel": "1.0.0-next.77"
 			}
 		},
 		"@sveltejs/adapter-cloudflare": {
-			"version": "1.0.0-next.31",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-1.0.0-next.31.tgz",
-			"integrity": "sha512-HhEFZP72GJ8AZGgFECKIiayDcLaAWi65pI0AnBfiNhCifYSlH/mPNWNVD4AWRDnXnH6XU+FLwhGDnIDwytTyYg==",
+			"version": "1.0.0-next.38",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-1.0.0-next.38.tgz",
+			"integrity": "sha512-N6jdTomRZkdKlcNoguwYD7lpdXSt0beIyUJsp0MS/YLm/4gI83y698zFYInFKJ9t5e6DAnuEBSAXcg568z2oFA==",
 			"dev": true,
 			"requires": {
 				"@cloudflare/workers-types": "^3.14.0",
-				"esbuild": "^0.14.48",
+				"esbuild": "^0.15.7",
 				"worktop": "0.8.0-next.14"
 			}
 		},
 		"@sveltejs/adapter-netlify": {
-			"version": "1.0.0-next.71",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.71.tgz",
-			"integrity": "sha512-la1CGtWO1xul1L3zEoFAoc4EX2uxZjrZcOMS3tkKB8drxhbQsNbnTE6fmSSMFiZXhxaikczrBgQwqIaDkLTmZg==",
+			"version": "1.0.0-next.78",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.78.tgz",
+			"integrity": "sha512-Yyn/j/0QcLK3Db442ducLUZmyvkO74j7Gdcwu9xN0fQN3kBlCJP9Itx5o4SySrPFGc4Q8cLJ5ELNg+mWduLBAA==",
 			"dev": true,
 			"requires": {
 				"@iarna/toml": "^2.2.5",
-				"esbuild": "^0.14.48",
-				"set-cookie-parser": "^2.4.8",
-				"tiny-glob": "^0.2.9"
+				"esbuild": "^0.15.7",
+				"set-cookie-parser": "^2.4.8"
 			}
 		},
 		"@sveltejs/adapter-vercel": {
-			"version": "1.0.0-next.66",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.66.tgz",
-			"integrity": "sha512-s3Hcxu9nCG/rR3C3cFbdQGjTa5W4K2kRcc6S5Xefx7itbrw+4v3KpO8ZPB6qM55XDwVxuG7260NMHVI6MUGmSA==",
+			"version": "1.0.0-next.77",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.77.tgz",
+			"integrity": "sha512-r4MqtP+lzx83HfcvI8PU0Yxzmxt6WQq9nzZETLboJouJzhSBUFIN5RmNZfEn6nNIlUwZbGQUEK/FxsRnnxI/Ig==",
 			"dev": true,
 			"requires": {
-				"@vercel/nft": "^0.21.0",
-				"esbuild": "^0.14.48"
+				"@vercel/nft": "^0.22.0",
+				"esbuild": "^0.15.7"
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.405",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.405.tgz",
-			"integrity": "sha512-jHSa74F7k+hC+0fof75g/xm/+1M5sM66Qt6v8eLLMSgjkp36Lb5xOioBhbl6w0NYoE5xysLsBWuu+yHytfvCBA==",
+			"version": "1.0.0-next.503",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.503.tgz",
+			"integrity": "sha512-QSEHe40qMOYjXirxS57dIa9NU4FntlYh+KYslBzasjMCfSiUkHGaWMJRz8uU+R4BWnThD9SdCo7F/NwDxu5LRQ==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.1",
-				"chokidar": "^3.5.3",
+				"@sveltejs/vite-plugin-svelte": "^1.0.5",
+				"@types/cookie": "^0.5.1",
+				"cookie": "^0.5.0",
+				"devalue": "^3.1.2",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.26.2",
+				"mime": "^3.0.0",
+				"node-fetch": "^3.2.4",
 				"sade": "^1.8.1",
-				"tiny-glob": "^0.2.9"
+				"set-cookie-parser": "^2.4.8",
+				"sirv": "^2.0.2",
+				"tiny-glob": "^0.2.9",
+				"undici": "^5.8.1"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.1.tgz",
-			"integrity": "sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.8.tgz",
+			"integrity": "sha512-1xkVTB4pm6zuign858FzVYE9Fdw9MQBOlxrdd85STV0NvTDmcofcRpcrK+zcIyT8SZ2dseHLu8hvDwzssF6RfA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^4.2.1",
 				"debug": "^4.3.4",
 				"deepmerge": "^4.2.2",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.2",
-				"svelte-hmr": "^0.14.12"
+				"magic-string": "^0.26.3",
+				"svelte-hmr": "^0.15.0"
 			}
 		},
 		"@tsconfig/svelte": {
@@ -3736,35 +3781,22 @@
 			"integrity": "sha512-pYrtLtOwku/7r1i9AMONsJMVYAtk3hzOfiGNekhtq5tYBGA7unMve8RvUclKLMT3PrihvJqUmzsRGh0RP84hKg==",
 			"dev": true
 		},
+		"@types/cookie": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
+			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
+			"dev": true
+		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
-		"@types/linkify-it": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-			"integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
-		},
-		"@types/markdown-it": {
-			"version": "12.2.3",
-			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-			"integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-			"requires": {
-				"@types/linkify-it": "*",
-				"@types/mdurl": "*"
-			}
-		},
-		"@types/mdurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-			"integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
-		},
 		"@types/node": {
-			"version": "18.7.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.3.tgz",
-			"integrity": "sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==",
+			"version": "18.7.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.21.tgz",
+			"integrity": "sha512-rLFzK5bhM0YPyCoTC8bolBjMk7bwnZ8qeZUBslBfjZQou2ssJdWslx9CZ8DGM+Dx7QXQiiTVZ/6QO6kwtHkZCA==",
 			"dev": true
 		},
 		"@types/pug": {
@@ -3783,16 +3815,15 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.0.tgz",
-			"integrity": "sha512-jHvZNSW2WZ31OPJ3enhLrEKvAZNyAFWZ6rx9tUwaessTc4sx9KmgMNhVcqVAl1ETnT5rU5fpXTLmY9YvC1DCNg==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.38.0.tgz",
+			"integrity": "sha512-GgHi/GNuUbTOeoJiEANi0oI6fF3gBQc3bGFYj40nnAPCbhrtEDf2rjBmefFadweBmO1Du1YovHeDP2h5JLhtTQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/type-utils": "5.33.0",
-				"@typescript-eslint/utils": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/type-utils": "5.38.0",
+				"@typescript-eslint/utils": "5.38.0",
 				"debug": "^4.3.4",
-				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
 				"regexpp": "^3.2.0",
 				"semver": "^7.3.7",
@@ -3800,52 +3831,53 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.0.tgz",
-			"integrity": "sha512-cgM5cJrWmrDV2KpvlcSkelTBASAs1mgqq+IUGKJvFxWrapHpaRy5EXPQz9YaKF3nZ8KY18ILTiVpUtbIac86/w==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
+			"integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/typescript-estree": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.0.tgz",
-			"integrity": "sha512-/Jta8yMNpXYpRDl8EwF/M8It2A9sFJTubDo0ATZefGXmOqlaBffEw0ZbkbQ7TNDK6q55NPHFshGBPAZvZkE8Pw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.0.tgz",
+			"integrity": "sha512-ByhHIuNyKD9giwkkLqzezZ9y5bALW8VNY6xXcP+VxoH4JBDKjU5WNnsiD4HJdglHECdV+lyaxhvQjTUbRboiTA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/visitor-keys": "5.33.0"
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/visitor-keys": "5.38.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.0.tgz",
-			"integrity": "sha512-2zB8uEn7hEH2pBeyk3NpzX1p3lF9dKrEbnXq1F7YkpZ6hlyqb2yZujqgRGqXgRBTHWIUG3NGx/WeZk224UKlIA==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.38.0.tgz",
+			"integrity": "sha512-iZq5USgybUcj/lfnbuelJ0j3K9dbs1I3RICAJY9NZZpDgBYXmuUlYQGzftpQA9wC8cKgtS6DASTvF3HrXwwozA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.33.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
+				"@typescript-eslint/utils": "5.38.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.0.tgz",
-			"integrity": "sha512-nIMt96JngB4MYFYXpZ/3ZNU4GWPNdBbcB5w2rDOCpXOVUkhtNlG2mmm8uXhubhidRZdwMaMBap7Uk8SZMU/ppw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.0.tgz",
+			"integrity": "sha512-HHu4yMjJ7i3Cb+8NUuRCdOGu2VMkfmKyIJsOr9PfkBVYLYrtMCK/Ap50Rpov+iKpxDTfnqvDbuPLgBE5FwUNfA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.0.tgz",
-			"integrity": "sha512-tqq3MRLlggkJKJUrzM6wltk8NckKyyorCSGMq4eVkyL5sDYzJJcMgZATqmF8fLdsWrW7OjjIZ1m9v81vKcaqwQ==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.0.tgz",
+			"integrity": "sha512-6P0RuphkR+UuV7Avv7MU3hFoWaGcrgOdi8eTe1NwhMp2/GjUJoODBTRWzlHpZh6lFOaPmSvgxGlROa0Sg5Zbyg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/visitor-keys": "5.33.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/visitor-keys": "5.38.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -3854,33 +3886,33 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.0.tgz",
-			"integrity": "sha512-JxOAnXt9oZjXLIiXb5ZIcZXiwVHCkqZgof0O8KPgz7C7y0HS42gi75PdPlqh1Tf109M0fyUw45Ao6JLo7S5AHw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.0.tgz",
+			"integrity": "sha512-6sdeYaBgk9Fh7N2unEXGz+D+som2QCQGPAf1SxrkEr+Z32gMreQ0rparXTNGRRfYUWk/JzbGdcM8NSSd6oqnTA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.33.0",
-				"@typescript-eslint/types": "5.33.0",
-				"@typescript-eslint/typescript-estree": "5.33.0",
+				"@typescript-eslint/scope-manager": "5.38.0",
+				"@typescript-eslint/types": "5.38.0",
+				"@typescript-eslint/typescript-estree": "5.38.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.33.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.0.tgz",
-			"integrity": "sha512-/XsqCzD4t+Y9p5wd9HZiptuGKBlaZO5showwqODii5C0nZawxWLF+Q6k5wYHBrQv96h6GYKyqqMHCSTqta8Kiw==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.0.tgz",
+			"integrity": "sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.33.0",
+				"@typescript-eslint/types": "5.38.0",
 				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
 		"@vercel/nft": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.21.0.tgz",
-			"integrity": "sha512-hFCAETfI5cG8l5iAiLhMC2bReC5K7SIybzrxGorv+eGspIbIFsVw7Vg85GovXm/LxA08pIDrAlrhR6GN36XB/Q==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.22.1.tgz",
+			"integrity": "sha512-lYYZIoxRurqDOSoVIdBicGnpUIpfyaS5qVjdPq+EfI285WqtZK3NK/dyCkiyBul+X2U2OEhRyeMdXPCHGJbohw==",
 			"dev": true,
 			"requires": {
 				"@mapbox/node-pre-gyp": "^1.0.5",
@@ -3979,7 +4011,8 @@
 		"argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -4013,11 +4046,6 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"bluebird": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4048,14 +4076,6 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
-		"catharsis": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-			"requires": {
-				"lodash": "^4.17.15"
-			}
-		},
 		"chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4079,6 +4099,16 @@
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.6.0"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
 			}
 		},
 		"chownr": {
@@ -4120,6 +4150,12 @@
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
 		},
+		"cookie": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"dev": true
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4130,6 +4166,12 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -4170,6 +4212,12 @@
 			"integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
 			"dev": true
 		},
+		"devalue": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-3.1.3.tgz",
+			"integrity": "sha512-9KO89Cb+qjzf2CqdrH+NuLaqdk9GhDP5EhR4zlkR51dvuIaiqtlkDkGzLMShDemwUy21raSMdu+kpX8Enw3yGQ==",
+			"dev": true
+		},
 		"dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4194,11 +4242,6 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
-		"entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-		},
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
@@ -4206,171 +4249,172 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.9.tgz",
+			"integrity": "sha512-OnYr1rkMVxtmMHIAKZLMcEUlJmqcbxBz9QoBU8G9v455na0fuzlT/GLu6l+SRghrk0Mm2fSSciMmzV43Q8e0Gg==",
 			"dev": true,
 			"requires": {
-				"@esbuild/linux-loong64": "0.14.54",
-				"esbuild-android-64": "0.14.54",
-				"esbuild-android-arm64": "0.14.54",
-				"esbuild-darwin-64": "0.14.54",
-				"esbuild-darwin-arm64": "0.14.54",
-				"esbuild-freebsd-64": "0.14.54",
-				"esbuild-freebsd-arm64": "0.14.54",
-				"esbuild-linux-32": "0.14.54",
-				"esbuild-linux-64": "0.14.54",
-				"esbuild-linux-arm": "0.14.54",
-				"esbuild-linux-arm64": "0.14.54",
-				"esbuild-linux-mips64le": "0.14.54",
-				"esbuild-linux-ppc64le": "0.14.54",
-				"esbuild-linux-riscv64": "0.14.54",
-				"esbuild-linux-s390x": "0.14.54",
-				"esbuild-netbsd-64": "0.14.54",
-				"esbuild-openbsd-64": "0.14.54",
-				"esbuild-sunos-64": "0.14.54",
-				"esbuild-windows-32": "0.14.54",
-				"esbuild-windows-64": "0.14.54",
-				"esbuild-windows-arm64": "0.14.54"
+				"@esbuild/android-arm": "0.15.9",
+				"@esbuild/linux-loong64": "0.15.9",
+				"esbuild-android-64": "0.15.9",
+				"esbuild-android-arm64": "0.15.9",
+				"esbuild-darwin-64": "0.15.9",
+				"esbuild-darwin-arm64": "0.15.9",
+				"esbuild-freebsd-64": "0.15.9",
+				"esbuild-freebsd-arm64": "0.15.9",
+				"esbuild-linux-32": "0.15.9",
+				"esbuild-linux-64": "0.15.9",
+				"esbuild-linux-arm": "0.15.9",
+				"esbuild-linux-arm64": "0.15.9",
+				"esbuild-linux-mips64le": "0.15.9",
+				"esbuild-linux-ppc64le": "0.15.9",
+				"esbuild-linux-riscv64": "0.15.9",
+				"esbuild-linux-s390x": "0.15.9",
+				"esbuild-netbsd-64": "0.15.9",
+				"esbuild-openbsd-64": "0.15.9",
+				"esbuild-sunos-64": "0.15.9",
+				"esbuild-windows-32": "0.15.9",
+				"esbuild-windows-64": "0.15.9",
+				"esbuild-windows-arm64": "0.15.9"
 			}
 		},
 		"esbuild-android-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.9.tgz",
+			"integrity": "sha512-HQCX7FJn9T4kxZQkhPjNZC7tBWZqJvhlLHPU2SFzrQB/7nDXjmTIFpFTjt7Bd1uFpeXmuwf5h5fZm+x/hLnhbw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.9.tgz",
+			"integrity": "sha512-E6zbLfqbFVCNEKircSHnPiSTsm3fCRxeIMPfrkS33tFjIAoXtwegQfVZqMGR0FlsvVxp2NEDOUz+WW48COCjSg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.9.tgz",
+			"integrity": "sha512-gI7dClcDN/HHVacZhTmGjl0/TWZcGuKJ0I7/xDGJwRQQn7aafZGtvagOFNmuOq+OBFPhlPv1T6JElOXb0unkSQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.9.tgz",
+			"integrity": "sha512-VZIMlcRN29yg/sv7DsDwN+OeufCcoTNaTl3Vnav7dL/nvsApD7uvhVRbgyMzv0zU/PP0xRhhIpTyc7lxEzHGSw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.9.tgz",
+			"integrity": "sha512-uM4z5bTvuAXqPxrI204txhlsPIolQPWRMLenvGuCPZTnnGlCMF2QLs0Plcm26gcskhxewYo9LkkmYSS5Czrb5A==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.9.tgz",
+			"integrity": "sha512-HHDjT3O5gWzicGdgJ5yokZVN9K9KG05SnERwl9nBYZaCjcCgj/sX8Ps1jvoFSfNCO04JSsHSOWo4qvxFuj8FoA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.9.tgz",
+			"integrity": "sha512-AQIdE8FugGt1DkcekKi5ycI46QZpGJ/wqcMr7w6YUmOmp2ohQ8eO4sKUsOxNOvYL7hGEVwkndSyszR6HpVHLFg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.9.tgz",
+			"integrity": "sha512-4RXjae7g6Qs7StZyiYyXTZXBlfODhb1aBVAjd+ANuPmMhWthQilWo7rFHwJwL7DQu1Fjej2sODAVwLbcIVsAYQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.9.tgz",
+			"integrity": "sha512-3Zf2GVGUOI7XwChH3qrnTOSqfV1V4CAc/7zLVm4lO6JT6wbJrTgEYCCiNSzziSju+J9Jhf9YGWk/26quWPC6yQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.9.tgz",
+			"integrity": "sha512-a+bTtxJmYmk9d+s2W4/R1SYKDDAldOKmWjWP0BnrWtDbvUBNOm++du0ysPju4mZVoEFgS1yLNW+VXnG/4FNwdQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.9.tgz",
+			"integrity": "sha512-Zn9HSylDp89y+TRREMDoGrc3Z4Hs5u56ozZLQCiZAUx2+HdbbXbWdjmw3FdTJ/i7t5Cew6/Q+6kfO3KCcFGlyw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.9.tgz",
+			"integrity": "sha512-OEiOxNAMH9ENFYqRsWUj3CWyN3V8P3ZXyfNAtX5rlCEC/ERXrCEFCJji/1F6POzsXAzxvUJrTSTCy7G6BhA6Fw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.9.tgz",
+			"integrity": "sha512-ukm4KsC3QRausEFjzTsOZ/qqazw0YvJsKmfoZZm9QW27OHjk2XKSQGGvx8gIEswft/Sadp03/VZvAaqv5AIwNA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.9.tgz",
+			"integrity": "sha512-uDOQEH55wQ6ahcIKzQr3VyjGc6Po/xblLGLoUk3fVL1qjlZAibtQr6XRfy5wPJLu/M2o0vQKLq4lyJ2r1tWKcw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.9.tgz",
+			"integrity": "sha512-yWgxaYTQz+TqX80wXRq6xAtb7GSBAp6gqLKfOdANg9qEmAI1Bxn04IrQr0Mzm4AhxvGKoHzjHjMgXbCCSSDxcw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.9.tgz",
+			"integrity": "sha512-JmS18acQl4iSAjrEha1MfEmUMN4FcnnrtTaJ7Qg0tDCOcgpPPQRLGsZqhes0vmx8VA6IqRyScqXvaL7+Q0Uf3A==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.9.tgz",
+			"integrity": "sha512-UKynGSWpzkPmXW3D2UMOD9BZPIuRaSqphxSCwScfEE05Be3KAmvjsBhht1fLzKpiFVJb0BYMd4jEbWMyJ/z1hQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.9.tgz",
+			"integrity": "sha512-aqXvu4/W9XyTVqO/hw3rNxKE1TcZiEYHPsXM9LwYmKSX9/hjvfIJzXwQBlPcJ/QOxedfoMVH0YnhhQ9Ffb0RGA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.9.tgz",
+			"integrity": "sha512-zm7h91WUmlS4idMtjvCrEeNhlH7+TNOmqw5dJPJZrgFaxoFyqYG6CKDpdFCQXdyKpD5yvzaQBOMVTCBVKGZDEg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
-			"version": "0.14.54",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"version": "0.15.9",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.9.tgz",
+			"integrity": "sha512-yQEVIv27oauAtvtuhJVfSNMztJJX47ismRS6Sv2QMVV9RM+6xjbMWuuwM2nxr5A2/gj/mu2z9YlQxiwoFRCfZA==",
 			"dev": true,
 			"optional": true
 		},
@@ -4381,14 +4425,15 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.22.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
-			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
+			"version": "8.24.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+			"integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.3.0",
-				"@humanwhocodes/config-array": "^0.10.4",
+				"@eslint/eslintrc": "^1.3.2",
+				"@humanwhocodes/config-array": "^0.10.5",
 				"@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+				"@humanwhocodes/module-importer": "^1.0.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -4398,13 +4443,12 @@
 				"eslint-scope": "^7.1.1",
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.3.3",
+				"espree": "^9.4.0",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
-				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^6.0.1",
 				"globals": "^13.15.0",
 				"globby": "^11.1.0",
@@ -4413,6 +4457,7 @@
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -4423,8 +4468,7 @@
 				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"eslint-scope": {
@@ -4442,15 +4486,6 @@
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
-				},
-				"glob-parent": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-					"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.3"
-					}
 				}
 			}
 		},
@@ -4502,9 +4537,9 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.3.3.tgz",
-			"integrity": "sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==",
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
+			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
@@ -4571,9 +4606,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4581,6 +4616,17 @@
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
 				"micromatch": "^4.0.4"
+			},
+			"dependencies": {
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
 			}
 		},
 		"fast-json-stable-stringify": {
@@ -4602,6 +4648,16 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
 			}
 		},
 		"file-entry-cache": {
@@ -4648,10 +4704,19 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
+		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"requires": {
+				"fetch-blob": "^3.1.2"
+			}
 		},
 		"fs-minipass": {
 			"version": "2.1.0",
@@ -4678,12 +4743,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
 			"dev": true
 		},
 		"gauge": {
@@ -4718,11 +4777,12 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
 			"requires": {
-				"is-glob": "^4.0.1"
+				"is-glob": "^4.0.3"
 			}
 		},
 		"globals": {
@@ -4763,7 +4823,8 @@
 		"graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true
 		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
@@ -4900,6 +4961,12 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"js-sdsl": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
+			"integrity": "sha512-Y2/yD55y5jteOAmY50JbUZYwk3CP3wnLPEZnlR1w9oKhITrBEtAxwuWKebFf8hMrPMgbYwFoWK/lH2sBkErELw==",
+			"dev": true
+		},
 		"js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4907,48 +4974,6 @@
 			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
-			}
-		},
-		"js2xmlparser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-			"requires": {
-				"xmlcreate": "^2.0.4"
-			}
-		},
-		"jsdoc": {
-			"version": "3.6.11",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-			"integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
-			"requires": {
-				"@babel/parser": "^7.9.4",
-				"@types/markdown-it": "^12.2.3",
-				"bluebird": "^3.7.2",
-				"catharsis": "^0.9.0",
-				"escape-string-regexp": "^2.0.0",
-				"js2xmlparser": "^4.0.2",
-				"klaw": "^3.0.0",
-				"markdown-it": "^12.3.2",
-				"markdown-it-anchor": "^8.4.1",
-				"marked": "^4.0.10",
-				"mkdirp": "^1.0.4",
-				"requizzle": "^0.2.3",
-				"strip-json-comments": "^3.1.0",
-				"taffydb": "2.6.2",
-				"underscore": "~1.13.2"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				}
 			}
 		},
 		"json-schema-traverse": {
@@ -4962,14 +4987,6 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true
-		},
-		"klaw": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-			"requires": {
-				"graceful-fs": "^4.1.9"
-			}
 		},
 		"kleur": {
 			"version": "4.1.5",
@@ -4987,14 +5004,6 @@
 				"type-check": "~0.4.0"
 			}
 		},
-		"linkify-it": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-			"integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-			"requires": {
-				"uc.micro": "^1.0.1"
-			}
-		},
 		"locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5003,11 +5012,6 @@
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
-		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",
@@ -5025,9 +5029,9 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.26.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
-			"integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+			"version": "0.26.4",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.4.tgz",
+			"integrity": "sha512-e5uXtVJ22aEpK9u1+eQf0fSxHeqwyV19K+uGnlROCxUhzwRip9tBsaMViK/0vC3viyPd5Gtucp3UmEp/Q2cPTQ==",
 			"dev": true,
 			"requires": {
 				"sourcemap-codec": "^1.4.8"
@@ -5050,34 +5054,6 @@
 				}
 			}
 		},
-		"markdown-it": {
-			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-			"integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-			"requires": {
-				"argparse": "^2.0.1",
-				"entities": "~2.1.0",
-				"linkify-it": "^3.0.1",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
-			}
-		},
-		"markdown-it-anchor": {
-			"version": "8.6.4",
-			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-			"integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
-			"requires": {}
-		},
-		"marked": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
-		},
-		"mdurl": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5093,6 +5069,12 @@
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
 			}
+		},
+		"mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+			"dev": true
 		},
 		"min-indent": {
 			"version": "1.0.1",
@@ -5173,13 +5155,21 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
 		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true
+		},
 		"node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "3.2.10",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+			"integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
 			"dev": true,
 			"requires": {
-				"whatwg-url": "^5.0.0"
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
 			}
 		},
 		"node-gyp-build": {
@@ -5312,9 +5302,9 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
 		},
 		"playwright-core": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
-			"integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.0.tgz",
+			"integrity": "sha512-p8huU8eU4gD3VkJd3DA1nA7R3XA6rFvFL+1RYS96cSljCF2yJE9CWEHTPF4LqX8KN9MoWCrAfVKP5381X3CZqg==",
 			"dev": true
 		},
 		"postcss": {
@@ -5390,14 +5380,6 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"requizzle": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-			"requires": {
-				"lodash": "^4.17.14"
-			}
-		},
 		"resolve": {
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -5431,9 +5413,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.77.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -5504,9 +5486,9 @@
 			}
 		},
 		"sass": {
-			"version": "1.54.4",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-			"integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+			"integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -5554,6 +5536,17 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
+		},
+		"sirv": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
+			"integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
+			"dev": true,
+			"requires": {
+				"@polka/url": "^1.0.0-next.20",
+				"mrmime": "^1.0.0",
+				"totalist": "^3.0.0"
+			}
 		},
 		"slash": {
 			"version": "3.0.0",
@@ -5625,7 +5618,8 @@
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -5643,15 +5637,15 @@
 			"dev": true
 		},
 		"svelte": {
-			"version": "3.49.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-			"integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+			"version": "3.50.1",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.50.1.tgz",
+			"integrity": "sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==",
 			"dev": true
 		},
 		"svelte-check": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.8.0.tgz",
-			"integrity": "sha512-HRL66BxffMAZusqe5I5k26mRWQ+BobGd9Rxm3onh7ZVu0nTk8YTKJ9vu3LVPjUGLU9IX7zS+jmwPVhJYdXJ8vg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.9.0.tgz",
+			"integrity": "sha512-9AVrtP7WbfDgCdqTZNPdj5CCCy1OrYMxFVWAWzNw7fl93c9klFJFtqzVXa6fovfQ050CcpUyJE2dPFL9TFAREw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.9",
@@ -5665,9 +5659,9 @@
 			}
 		},
 		"svelte-hmr": {
-			"version": "0.14.12",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.12.tgz",
-			"integrity": "sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.0.tgz",
+			"integrity": "sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==",
 			"dev": true,
 			"requires": {}
 		},
@@ -5695,11 +5689,6 @@
 					}
 				}
 			}
-		},
-		"taffydb": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
 		},
 		"tar": {
 			"version": "6.1.11",
@@ -5747,6 +5736,12 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"totalist": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.0.tgz",
+			"integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
+			"dev": true
+		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5792,20 +5787,16 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true
 		},
-		"uc.micro": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-		},
-		"underscore": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-			"integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+		"undici": {
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
+			"integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==",
+			"dev": true
 		},
 		"uri-js": {
 			"version": "4.4.1",
@@ -5822,24 +5813,24 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-			"dev": true
-		},
 		"vite": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.7.tgz",
-			"integrity": "sha512-dILhvKba1mbP1wCezVQx/qhEK7/+jVn9ciadEcyKMMhZpsuAi/eWZfJRMkmYlkSFG7Qq9NvJbgFq4XOBxugJsA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
+			"integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.14.47",
+				"esbuild": "^0.15.6",
 				"fsevents": "~2.3.2",
 				"postcss": "^8.4.16",
 				"resolve": "^1.22.1",
-				"rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+				"rollup": "~2.78.0"
 			}
+		},
+		"web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "3.0.1",
@@ -5896,11 +5887,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
-		},
-		"xmlcreate": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
 		},
 		"yallist": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lettra-client",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -32,7 +32,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"jsdoc": "^3.6.11",
 		"sass": "^1.54.0"
 	}
 }

--- a/src/components/editor/Editor.svelte
+++ b/src/components/editor/Editor.svelte
@@ -2,7 +2,7 @@
 	import { parsedText, text } from '$stores/text';
 	import LiveText from '$text/LiveText.svelte';
 
-	let value: string = '';
+	let value = '';
 
 	$: text.set(value);
 </script>

--- a/src/components/editor/text/LiveText.svelte
+++ b/src/components/editor/text/LiveText.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { getStringFromText, splitText } from '$src/lib/editor';
-	import { powerWordiables } from '$src/lib/wordiables';
-	import type { WordI } from '$src/types';
+	import { getStringFromText, splitText } from '$lib/editor';
+	import { powerWordiables } from '$lib/wordiables';
+	import type { WordI } from '$lib/types';
 	import Word from '$text/Word.svelte';
 
 	export let text: WordI[] = [];

--- a/src/components/editor/text/Word.svelte
+++ b/src/components/editor/text/Word.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WordI } from '$src/types';
+	import type { WordI } from '$lib/types';
 
 	export let word: WordI;
 	let color: string = word.color;

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -1,4 +1,5 @@
 import { regex } from '$lib/regex';
+import type { WordI } from '$lib/types';
 
 export const replaceNewlines = (str: string): string => {
 	return str.replace(regex.newline, ' <br> ');
@@ -15,16 +16,14 @@ export const getStringFromText = (text: WordI[]): string => {
 	}, '');
 };
 
-export const objectifyWords = (words: string[]): WordI => {
-	return words.reduce((acc, word, index) => {
-		const wordExpanded: WordI = {
-			string: replaceNewlines(word),
-			index: index + 1,
+export const objectifyWords = (words: string[]): WordI[] => {
+	return words.map((word: string, index: number): WordI => {
+		return {
+			string: word,
+			index,
 			isWordiable: false,
-			color: 'black',
-			wordiablePos: null
+			color: '',
+			wordiablePos: -1
 		};
-		acc.push(wordExpanded);
-		return acc;
-	}, []);
+	});
 };

--- a/src/lib/regex.ts
+++ b/src/lib/regex.ts
@@ -1,4 +1,4 @@
-import type { RegexI } from '$src/types';
+import type { RegexI } from '$lib/types';
 
 export const regex: RegexI = {
 	wordiables: /\\(.*?)\\/g,

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -3,7 +3,7 @@ export type WordI = {
 	index: number;
 	isWordiable: boolean;
 	color: string;
-	wordiablePos: null | number;
+	wordiablePos: number;
 };
 
 export type RegexI = {

--- a/src/lib/wordiables.ts
+++ b/src/lib/wordiables.ts
@@ -1,30 +1,31 @@
 import { wordiables } from '$stores/text';
 import { regex } from '$lib/regex';
+import type { WordI } from '$lib/types';
 
 let matchedWords: string[] = [];
 
 const rainbow = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet', 'black'];
 
-const setWordiables = (word: string): never => {
+const setWordiables = (word: string): void => {
 	wordiables.set([...matchedWords, word]);
 };
 
-const findWordiables = (text: string[]): string => {
+const findWordiables = (text: string[]): string | undefined => {
 	return text.find((word) => {
 		const isNotInMatchedWords = !matchedWords.includes(word);
-		const hasOnlyTwoForwardSlashes = word.match(regex.backslash).length === 2;
+		const hasOnlyTwoForwardSlashes: boolean = word.match(regex.backslash)?.length === 2;
 		const isWordiable = isNotInMatchedWords && hasOnlyTwoForwardSlashes;
 		if (isWordiable) setWordiables(word);
 	});
 };
 
-const syncWordiables = (str: string[]): never => {
+const syncWordiables = (str: string[]): void => {
 	matchedWords.forEach((word) => {
 		if (!str.includes(word)) wordiables.set(matchedWords.filter((w) => w !== word));
 	});
 };
 
-const sortMatchedWords = (str: string[]): never => {
+const sortMatchedWords = (str: string[]): void => {
 	matchedWords.sort((a, b) => {
 		const aIndex = str.indexOf(a);
 		const bIndex = str.indexOf(b);
@@ -32,7 +33,7 @@ const sortMatchedWords = (str: string[]): never => {
 	});
 };
 
-const syncMatches = (text: string[]): never => {
+const syncMatches = (text: string[]): undefined => {
 	if (text.length < 1) return;
 	findWordiables(text);
 	syncWordiables(text);
@@ -43,14 +44,17 @@ const isWordiable = (word: string): boolean => {
 	if (!matchedWords.length) return false;
 	const match = word.match(regex.wordiables);
 	if (match) return true;
+	return false;
 };
 
 const getWordiablePos = (word: string): number => {
-	const [match] = word.match(regex.wordiables);
+	const [match]: RegExpMatchArray = word.match(regex.wordiables) || [];
 	if (match) return matchedWords.indexOf(match);
+
+	return -1;
 };
 
-export const powerWordiables = (text: object[]): never => {
+export const powerWordiables = (text: WordI[]): void => {
 	text.forEach((t) => {
 		if (isWordiable(t.string)) {
 			t.isWordiable = true;
@@ -62,7 +66,7 @@ export const powerWordiables = (text: object[]): never => {
 
 export const checkForWordiables = (text: string): string => {
 	wordiables.subscribe((words) => (matchedWords = words));
-	const matches: string[] = text.match(regex.wordiables);
+	const matches = text.match(regex.wordiables);
 	if (matches) syncMatches(matches);
 	return text;
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,8 +15,10 @@
 			<h2>by Andrew Vallejo</h2>
 		</div>
 	</header>
-	<Editor />
-	<Table />
+	<main class="layout">
+		<Table />
+		<Editor />
+	</main>
 </div>
 
 <style lang="scss">
@@ -53,5 +55,11 @@
 			align-items: center;
 			display: flex;
 		}
+	}
+
+	.layout {
+		display: flex;
+		width: 100%;
+		height: 100%;
 	}
 </style>

--- a/src/stores/text.ts
+++ b/src/stores/text.ts
@@ -1,15 +1,17 @@
 import { derived, writable } from 'svelte/store';
-import { objectifyWords, splitText, replaceNewlines } from '$src/lib/editor';
-import { checkForWordiables } from '$src/lib/wordiables';
+import { objectifyWords, splitText, replaceNewlines } from '$lib/editor';
+import { checkForWordiables } from '$lib/wordiables';
+import type { WordI } from '$lib/types';
+import type { Writable } from 'svelte/store';
 
-export const text = writable('');
+export const text: Writable<string> = writable('');
 
-export const parsedText = derived(text, ($text) => {
+export const parsedText = derived(text, ($text): WordI[] => {
 	checkForWordiables($text);
 	const words = splitText(replaceNewlines($text));
 	return objectifyWords(words);
 });
 
-export const wordiables: never = writable([]);
+export const wordiables: Writable<string[]> = writable([]);
 
-export const isSync = writable(true);
+export const isSync: Writable<boolean> = writable(true);


### PR DESCRIPTION
This PR fixes all type errors when entering `npm run check` in the terminal. This also upgrades Sveltekit to 1.0 with minor changes made to Routes due to migration. 

