### PR TITLE
Fix/instructions prefire

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lettra-client",
-	"version": "0.0.5",
+	"version": "0.0.5.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -9,17 +9,17 @@
 
 	let instructionsActive = true;
 
-	const clearEditor = () => {
-		value = '';
-		instructionsActive = false;
-	};
+	let textArea: HTMLTextAreaElement;
 
-	const onKeyDown = () => {
-		if (!instructionsActive) return;
-		clearEditor();
-	};
+	const clearEditor = () => (value = '');
 
-	$: !value && wordiables.set([]);
+	const handleKeyDown = (event: KeyboardEvent): void => {
+		instructionsActive && event.preventDefault();
+		if (instructionsActive && value.length >= $instructions.length) {
+			instructionsActive = false;
+			clearEditor();
+		}
+	};
 
 	const spliceInstructions = () => {
 		if (!instructionsActive) return;
@@ -31,13 +31,15 @@
 			}
 		}, 25);
 	};
-	$: !value && instructionsActive && spliceInstructions();
+
 	$: checkForWordiables(value);
+	$: !value && instructionsActive && spliceInstructions();
+	$: !value && wordiables.set([]);
 	$: text.set(value);
+	$: !instructionsActive && textArea && textArea.focus();
 </script>
 
-<svelte:window on:keydown={onKeyDown} />
-
+<svelte:window on:keydown={handleKeyDown} />
 <div class="editor">
 	<div class="container">
 		{#if value}
@@ -58,7 +60,7 @@
 		{/if}
 
 		<label for="editor">Editor</label>
-		<textarea id="editor" name="editor" class="text-input" bind:value />
+		<textarea id="editor" name="editor" class="text-input" bind:value bind:this={textArea} />
 	</div>
 </div>
 


### PR DESCRIPTION
Before this PR, this instructions printing on the screen could be interrupted by user inputs. Now the user has to wait for instructions to be finished being entered before being able to move on (by pressing any key). Once a key is pressed, the user is then automatically focused on the textarea. 