### PR TITLE
Feat/desktop screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lettra-client",
-	"version": "0.0.5.1",
+	"version": "0.0.5.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -53,7 +53,7 @@
 							<Word {word} />
 						{/if}
 						{#if word.string !== '<br>'}
-							{@html space}
+							{space}
 						{/if}
 					{/key}
 				{/each}

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -32,6 +32,7 @@
 		}, 25);
 	};
 
+	let inactive: boolean = instructionsActive;
 	$: checkForWordiables(value);
 	$: !value && instructionsActive && spliceInstructions();
 	$: !value && wordiables.set([]);
@@ -40,7 +41,7 @@
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />
-<div class="editor">
+<div class="editor" class:inactive>
 	<div class="container">
 		{#if value}
 			<p class="live-text">
@@ -58,7 +59,6 @@
 				{/each}
 			</p>
 		{/if}
-
 		<label for="editor">Editor</label>
 		<textarea id="editor" name="editor" class="text-input" bind:value bind:this={textArea} />
 	</div>
@@ -66,6 +66,7 @@
 
 <style lang="scss">
 	.editor {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -74,7 +75,19 @@
 		height: clamp(28rem, 94%, 50rem);
 		border: 20px solid #e5e5e5;
 		border-radius: 7px;
-
+		&.inactive {
+			&::before {
+				content: '';
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				z-index: 2;
+				cursor: text;
+				pointer-events: painted;
+			}
+		}
 		label[for='editor'] {
 			font-size: 0;
 		}
@@ -82,6 +95,7 @@
 			position: relative;
 			width: 100%;
 			height: 100%;
+
 			.live-text {
 				z-index: 1;
 				position: absolute;

--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -32,7 +32,6 @@
 		}, 25);
 	};
 
-	let inactive: boolean = instructionsActive;
 	$: checkForWordiables(value);
 	$: !value && instructionsActive && spliceInstructions();
 	$: !value && wordiables.set([]);
@@ -41,7 +40,7 @@
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />
-<div class="editor" class:inactive>
+<div class="editor" class:inactive={instructionsActive}>
 	<div class="container">
 		{#if value}
 			<p class="live-text">
@@ -65,16 +64,23 @@
 </div>
 
 <style lang="scss">
+	@media (max-width: 800px) {
+		.editor {
+			height: 100%;
+		}
+	}
 	.editor {
 		position: relative;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-		width: 100rem;
-		height: clamp(28rem, 94%, 50rem);
+		width: 65rem;
+		min-width: 25rem;
+		height: clamp(13rem, 94%, 50rem);
 		border: 20px solid #e5e5e5;
 		border-radius: 7px;
+
 		&.inactive {
 			&::before {
 				content: '';
@@ -85,7 +91,6 @@
 				height: 100%;
 				z-index: 2;
 				cursor: text;
-				pointer-events: painted;
 			}
 		}
 		label[for='editor'] {

--- a/src/components/Pane.svelte
+++ b/src/components/Pane.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	export let direction: string;
+</script>
+
+<section class="pane {direction}">
+	<slot />
+</section>
+
+<style lang="scss">
+	.pane {
+		align-self: flex-end;
+		width: 100%;
+		height: calc(100% - 1.9rem);
+		&.left,
+		&.right {
+			display: flex;
+			justify-content: center;
+			width: 40rem;
+			height: 100%;
+			padding-block-start: 3rem;
+		}
+	}
+</style>

--- a/src/components/Table.svelte
+++ b/src/components/Table.svelte
@@ -11,7 +11,7 @@
 <div class="container">
 	<header class="categories">
 		<h2>wordiables</h2>
-		<h2>occurences</h2>
+		<h2 class="occurences">occurences</h2>
 	</header>
 
 	{#each $wordiables as wordiable, i}
@@ -22,24 +22,37 @@
 				</h3>
 				<div class="circle" style="background: {rainbow[i]}" in:fade />
 			</div>
-			<h4 transition:fade={{ delay: 250 }}>0</h4>
+			<h4 class="occurences" transition:fade={{ delay: 250 }}>0</h4>
 		</article>
 		<div class="line" style="background: {rainbow[i]}" in:fade />
 	{/each}
 </div>
 
 <style lang="scss">
+	@media (max-width: 1200px) {
+		.occurences {
+			display: none;
+		}
+	}
+
+	@media (max-width: 800px) {
+		.container {
+			display: none;
+		}
+	}
 	.container {
 		position: relative;
-		width: 18rem;
+		padding-inline: 1rem;
 		height: 15rem;
 		padding: 0.5rem 1rem;
 		border: 1px solid grey;
 		border-radius: 7px;
+		overflow-y: scroll;
 		.categories {
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
+			gap: 1rem;
 			h2 {
 				font-weight: 400;
 				font-size: 1.2rem;
@@ -62,6 +75,7 @@
 				align-items: center;
 				gap: 0 4px;
 			}
+
 			.circle {
 				width: 0.5rem;
 				height: 0.5rem;

--- a/src/components/Word.svelte
+++ b/src/components/Word.svelte
@@ -19,7 +19,6 @@
 	};
 
 	$: font = word.isWordiable ? 'wordiable' : 'word';
-
 	$: color.set(rainbow[word.wordiablePos]);
 </script>
 

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -5,7 +5,7 @@ export const replaceNewlines = (str: string): string => {
 	return str.replace(regex.newLine, ' <br> ');
 };
 
-export const space = '&nbsp;';
+export const space = ' ';
 
 export const splitText = (text: string): string[] => text.split(' ');
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,11 @@
 </footer>
 
 <style lang="scss">
+	@media (max-width: 500px) {
+		header {
+			background: hsl(0deg 0% 90%);
+		}
+	}
 	header {
 		display: flex;
 		position: relative;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Editor from '$components/Editor.svelte';
+	import Pane from '$components/Pane.svelte';
 	import Table from '$components/Table.svelte';
 </script>
 
@@ -8,13 +9,11 @@
 </svelte:head>
 
 <main class="layout">
-	<section class="pane left">
+	<Pane direction="left">
 		<Table />
-	</section>
-
+	</Pane>
 	<Editor />
-
-	<section class="pane right" />
+	<Pane direction="right" />
 </main>
 
 <style lang="scss">
@@ -42,17 +41,5 @@
 		width: 100%;
 		height: 100%;
 		overflow: hidden;
-		.pane {
-			align-self: flex-end;
-			width: 100%;
-			height: calc(100% - 1.9rem);
-		}
-	}
-	.left {
-		display: flex;
-		justify-content: center;
-		width: 20%;
-		height: 100%;
-		padding-block-start: 1rem;
 	}
 </style>


### PR DESCRIPTION
This PR does a few things but the main one is that media queries have been added for desktop screens! 

- On either side of the editor are Panes (think Figma) 
- No `@html` found at all throughout codebase  ◡̈  
- When instructions is rolling, its now more obvious that its disabled.
- Media queries added (only tested with desktop views)