### PR TITLE
Hotfix/instructions spacing

### DIFF
--- a/src/components/Editor.svelte
+++ b/src/components/Editor.svelte
@@ -128,12 +128,13 @@
 
 			.text-input {
 				position: absolute;
-				width: 100%;
+				width: 101%;
 				height: inherit;
 				padding: 0;
 				border: 2.5px solid grey;
 				outline: none;
 				color: transparent;
+				color: pink;
 				resize: none;
 				background: eggshell;
 				caret-color: black;

--- a/src/stores/instructions.ts
+++ b/src/stores/instructions.ts
@@ -1,12 +1,8 @@
 import { writable } from 'svelte/store';
-
-type Instructions = {
-	prompt: string;
-	active: boolean;
-};
+import type { Instructions } from '../types';
 
 const store: Instructions = {
-	prompt: `In order to create a wordiable, you must surround it with two backslashes. \n For Example, the words \\flamingo\\ and \\doctor\\ are now wordiables.\n With every following iteration of the word's colors corresponding with it.\n I am applying for the \\doctor\\ role at \\flamingo\\ inc. \n Hit any key to clear editor and begin!`,
+	prompt: `In order to create a wordiable, you must surround it with two backslashes.\n \n For Example, the words \\flamingo\\ and \\doctor\\ are now wordiables.\n \n With every following iteration of the word's colors corresponding with it.\n \n I am applying for the \\doctor\\ role at \\flamingo\\ inc.\n \n Hit any key to clear editor and begin!`,
 	active: true
 };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,3 +18,8 @@ export type Regex = {
 type Words = Word[];
 
 type Wordiables = Word[];
+
+type Instructions = {
+	active: boolean;
+	prompt: string;
+};


### PR DESCRIPTION
After I had fixed the linebreak issue, I had forgotten to add them back! This PR fixes that.

## Demo

> The pink text you see is the real user input. This is as close as i could get the live text and input text to line up. (for now!)

>Also notice that with every double line break, the text becomes more aligned 

<img width="657" alt="Screen Shot 2022-10-08 at 11 12 05 AM" src="https://user-images.githubusercontent.com/17935770/194719366-4da98b59-437b-4506-b5ea-93ce230a508f.png">
